### PR TITLE
feat(mail): update nodemailer configuration for STARTTLS

### DIFF
--- a/src/services/email-service/email-manager.ts
+++ b/src/services/email-service/email-manager.ts
@@ -12,11 +12,14 @@ export class EmailManager implements IEmailManager {
   constructor(auth_user = INFO_EMAIL, auth_pass = INFO_EMAIL_PASSWORD) {
     this.transporter = nodemailer.createTransport({
       host: 'smtpi.kinghost.net',
-      port: 465,
-      secure: true,
+      port: 587,
+      secure: false,
       auth: {
         user: auth_user,
         pass: auth_pass
+      },
+      tls: {
+        rejectUnauthorized: false
       }
     });
   }


### PR DESCRIPTION
- Set 'secure' to 'false' to support STARTTLS on port 587.
- Added 'rejectUnauthorized: false' in 'tls' options to handle potential certificate issues.