### PR TITLE
fix: remove required permission from GET /book-evaluations

### DIFF
--- a/src/presentation/api/book-evaluation.ts
+++ b/src/presentation/api/book-evaluation.ts
@@ -63,7 +63,7 @@ export class BookEvaluationAPI extends Controller {
    */
 
   @Get('/')
-  @Security('jwt', ['bookPermission'])
+  @Security('jwt')
   @Middlewares(paginationMiddleware)
   @SuccessResponse(200, 'Successfully generated the metrics')
   public async getVBookEvaluationList(


### PR DESCRIPTION
Remove required permission from GET /book-evaluations